### PR TITLE
build: migrate to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unimarkup-rs"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
As discussed in issue #5 we should migrate to the newest Rust edition (2021) before the project gets too big. Right now, there are no changes needed in order to use Rust 2021. Should we one day release parts of `unimarkup-rs` as a library, we would have a requirement for the lowest version of `rustc`. For edition 2021, lowest `rustc` version is `1.56`

To update your toolchain to be compatible with Rust 2021, use `rustup`: 

```
rustup update stable
```

Closes #5 