### PR TITLE
fix: do not panic when config validation fails

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
         match Config::try_parse() {
             Ok(cfg) => {
                 if let Err(err) = cfg.validate() {
-                    logid::log!(GeneralError::Compile, &format!("Compilation failed: {err}"));
+                    logid::log!(GeneralError::Compile, &format!("Configuration is invalid: {err}"));
                     break 'outer;
                 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,10 @@ fn main() {
         match Config::try_parse() {
             Ok(cfg) => {
                 if let Err(err) = cfg.validate() {
-                    logid::log!(GeneralError::Compile, &format!("Configuration is invalid: {err}"));
+                    logid::log!(
+                        GeneralError::Compile,
+                        &format!("Configuration is invalid: {err}")
+                    );
                     break 'outer;
                 }
 

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -23,7 +23,7 @@ icu_locid = "=1.2.0"
 icu_segmenter = "=1.2.0"
 icu_provider = { version = "=1.2.0" }
 icu_provider_blob = "=1.2.0"
-icu_datagen = { version = "=1.2.5", features = ["networking"] }
+icu_datagen = { version = "=1.2.5", default-features=false, features = [ "networking" ] }
 regex = { version = "1.8.1", optional = true }
 insta = {version = "1.29.0", features = ["serde"], optional = true}
 

--- a/commons/src/config/log_id.rs
+++ b/commons/src/config/log_id.rs
@@ -20,6 +20,6 @@ pub enum ConfigErr {
     #[error("Given locale is not in default locales data. Please provide data or use one of supported default locales: en-US, de-AT, bs-BA")]
     BadLocaleUsed,
     /// Log-id denoting provided locales are not included in default locales data
-    #[error("Given locale is missing keys in the used data file. Falling back to default locale for the given language.")]
-    LocaleMissingKeys,
+    #[error("Given locale is incompatible with data file. Using falling locale '{}'.", .0)]
+    LocaleMissingKeys(String),
 }

--- a/commons/src/config/log_id.rs
+++ b/commons/src/config/log_id.rs
@@ -19,7 +19,4 @@ pub enum ConfigErr {
     /// Log-id denoting provided locales are not included in default locales data
     #[error("Given locale is not in default locales data. Please provide data or use one of supported default locales: en-US, de-AT, bs-BA")]
     BadLocaleUsed,
-    /// Log-id denoting provided locales are not included in default locales data
-    #[error("Given locale is incompatible with data file. Using falling locale '{}'.", .0)]
-    LocaleMissingKeys(String),
 }

--- a/commons/src/config/mod.rs
+++ b/commons/src/config/mod.rs
@@ -76,6 +76,7 @@ impl ConfigFns for Config {
                 &format!("Input file not found: {:?}", self.input)
             );
         }
+
         Ok(())
     }
 }

--- a/commons/src/config/preamble.rs
+++ b/commons/src/config/preamble.rs
@@ -9,7 +9,7 @@ use icu_datagen::{all_keys, Out, SourceData};
 use icu_locid::{langid, LanguageIdentifier, Locale};
 
 use icu_provider::{BufferProvider, DataRequest};
-use logid::{err, logging::event_entry::AddonKind, pipe};
+use logid::{err, log_id::LogLevel, logging::event_entry::AddonKind, pipe};
 use serde::{Deserialize, Serialize};
 
 use super::{locale, log_id::ConfigErr, parse_to_hashset, ConfigFns, ReplaceIfNone};
@@ -141,10 +141,10 @@ impl ConfigFns for I18n {
 
             if provider.load_buffer(key, req).is_err() {
                 logid::log!(
-                    ConfigErr::LocaleMissingKeys(locale.id.language.to_string()),
-                    add: AddonKind::Info(
+                    logid::new_log_id!("LocaleKeyMissing", LogLevel::Debug),
+                    add: AddonKind::Debug(
                         format!(
-                            "Locale {} is not contained in the provided file. Trying to use fallback locale '{}'.",
+                            "Locale {} is not contained in the given locales file. Using fallback locale '{}'.",
                             locale,
                             locale.id.language
                         )

--- a/commons/src/config/preamble.rs
+++ b/commons/src/config/preamble.rs
@@ -92,7 +92,28 @@ impl ConfigFns for I18n {
                 .iter()
                 .all(|langid| allowed_locales.contains(&langid.id))
             {
-                return err!(ConfigErr::BadLocaleUsed);
+                return err!(
+                    ConfigErr::BadLocaleUsed,
+                    &format!(
+                        "{} locale(s) not supported by default. Only the following locales are allowed: {}.",
+                        locales
+                            .iter()
+                            .filter(|l| !allowed_locales.contains(&l.id))
+                            .map(|langid| langid.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        allowed_locales
+                            .iter()
+                            .map(|langid| langid.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                    add: AddonKind::Info(
+                        String::from(
+                            "Use --locales-file (and --download-locales) when using non-default locales."
+                        )
+                    )
+                );
             }
         }
 
@@ -120,7 +141,7 @@ impl ConfigFns for I18n {
 
             if provider.load_buffer(key, req).is_err() {
                 logid::log!(
-                    ConfigErr::LocaleMissingKeys,
+                    ConfigErr::LocaleMissingKeys(locale.id.language.to_string()),
                     add: AddonKind::Info(
                         format!(
                             "Locale {} is not contained in the provided file. Trying to use fallback locale '{}'.",

--- a/commons/src/config/preamble.rs
+++ b/commons/src/config/preamble.rs
@@ -48,7 +48,7 @@ impl ConfigFns for Preamble {
 
 #[derive(Args, Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct I18n {
-    #[arg(long, value_parser = locale::clap::parse_locale, default_value = "en-US")]
+    #[arg(long, value_parser = locale::clap::parse_locale, default_value = "en")]
     #[serde(with = "locale::serde::single")]
     pub lang: Locale,
 


### PR DESCRIPTION
Previously `unwrap` was called on config validation result in `cli` crate. 

That was incorrect, because the config can (and should) return `Err` if something is not right. This PR fixes that, and improves error messages displayed.

Fixes #95. 