### PR TITLE
feat: add log filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 license = "MIT"
 
 [workspace.dependencies]
-logid = { version = "0.11", features = ["diagnostics"] }
+logid = { version = "0.12.1", features = ["diagnostics"] }
 thiserror = "1.0"
 once_cell = "1.13.0"
 clap = { version = "4.2.7", features = ["derive", "cargo", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 license = "MIT"
 
 [workspace.dependencies]
-logid = { version = "0.9", features = ["diagnostics"] }
+logid = { version = "0.11", features = ["diagnostics"] }
 thiserror = "1.0"
 once_cell = "1.13.0"
 clap = { version = "4.2.7", features = ["derive", "cargo", "env"] }

--- a/cli/src/compiler.rs
+++ b/cli/src/compiler.rs
@@ -24,7 +24,7 @@ pub fn compile(config: Config) -> Result<(), GeneralError> {
     let source = fs::read_to_string(&config.input).map_err(|error| {
         pipe!(
             GeneralError::FileRead,
-            &format!("Could not read file: '{:?}'", &config.input),
+            format!("Could not read file: '{:?}'", &config.input),
             add: AddonKind::Info(format!("Cause: {}", error))
         )
     })?;
@@ -66,13 +66,13 @@ fn write_file(
 
     log!(
         GeneralInfo::WritingToFile,
-        &format!("Writing to file: {:?}", full_out_path),
+        format!("Writing to file: {:?}", full_out_path),
     );
 
     std::fs::write(&full_out_path, content).map_err(|error| {
         pipe!(
             GeneralError::FileWrite,
-            &format!("Could not write to file: {:?}", full_out_path),
+            format!("Could not write to file: {:?}", full_out_path),
             add: AddonKind::Info(format!("Cause: {}", error))
         )
     })

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,13 @@
 use clap::Parser;
-use logid::{event_handler::builder::LogEventHandlerBuilder, log, logging::event_entry::AddonKind};
+use logid::{
+    event_handler::builder::LogEventHandlerBuilder,
+    log,
+    log_id::LogLevel,
+    logging::{
+        event_entry::AddonKind,
+        filter::{AddonFilter, FilterConfigBuilder},
+    },
+};
 use unimarkup_commons::config::{Config, ConfigFns};
 
 use crate::log_id::{GeneralError, GeneralInfo};
@@ -8,7 +16,11 @@ mod compiler;
 mod log_id;
 
 fn main() {
-    let _ = logid::set_filter!("info(infos)");
+    let _ = logid::logging::filter::set_filter(
+        FilterConfigBuilder::new(LogLevel::Info)
+            .allowed_addons(AddonFilter::Infos)
+            .build(),
+    );
 
     let _handler = LogEventHandlerBuilder::new()
         .to_stderr()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
                 if let Err(err) = cfg.validate() {
                     logid::log!(
                         GeneralError::Compile,
-                        &format!("Configuration is invalid: {err}")
+                        format!("Configuration is invalid: {err}")
                     );
                     break 'outer;
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use logid::{event_handler::LogEventHandlerBuilder, log, logging::event_entry::AddonKind};
+use logid::{event_handler::builder::LogEventHandlerBuilder, log, logging::event_entry::AddonKind};
 use unimarkup_commons::config::{Config, ConfigFns};
 
 use crate::log_id::{GeneralError, GeneralInfo};
@@ -8,8 +8,10 @@ mod compiler;
 mod log_id;
 
 fn main() {
-    let log_handler = LogEventHandlerBuilder::new()
-        .write_to_console()
+    let _ = logid::set_filter!("info(infos)");
+
+    let _handler = LogEventHandlerBuilder::new()
+        .to_stderr()
         .all_log_events()
         .build();
 
@@ -38,6 +40,4 @@ fn main() {
             );
         }
     }
-
-    log_handler.shutdown();
 }

--- a/cli/tests/logging/cli_logs.rs
+++ b/cli/tests/logging/cli_logs.rs
@@ -13,20 +13,23 @@ fn test__main_log_trace__attributes_file() {
     path.push(format!("tests/test_files/{}", TEST_FILE));
 
     let cli_proc = Command::new("cargo")
-        .stdout(Stdio::piped())
-        .args(["run", "--", "--formats=html", &path.to_string_lossy()])
+        .stderr(Stdio::piped())
+        .args([
+            "run",
+            "--",
+            "--formats=html",
+            "--lang=en",
+            &path.to_string_lossy(),
+        ])
         .spawn()
         .expect("Failed to spawn 'cargo run'");
 
     let output = cli_proc
         .wait_with_output()
         .expect("Failed to execute 'cargo run'");
-    let logs = String::from_utf8_lossy(&output.stdout);
+    let logs = String::from_utf8_lossy(&output.stderr);
 
-    assert!(logs.contains("INFO: Writing to file: "));
+    assert!(logs.contains("Writing to file: "));
     assert!(logs.contains(&TEST_FILE.replace(".um", ".html")));
-    // assert!(logs.contains("64(origin): file="));
-    assert!(logs.contains("INFO: Unimarkup finished compiling."));
-    // assert!(logs.contains(TEST_FILE));
-    // assert!(logs.contains("65(origin): file="));
+    assert!(logs.contains("Unimarkup finished compiling."));
 }

--- a/commons/src/config/mod.rs
+++ b/commons/src/config/mod.rs
@@ -73,7 +73,7 @@ impl ConfigFns for Config {
         if !self.input.exists() {
             return err!(
                 ConfigErr::InvalidFile,
-                &format!("Input file not found: {:?}", self.input)
+                format!("Input file not found: {:?}", self.input)
             );
         }
         Ok(())
@@ -89,7 +89,7 @@ impl Config {
             .map_err(|_| {
                 pipe!(
                     ConfigErr::InvalidFile,
-                    &format!(
+                    format!(
                         "Failed to read locales file: {:?}",
                         locales_file.as_ref().map(|p| p.to_string_lossy())
                     )

--- a/commons/src/config/output.rs
+++ b/commons/src/config/output.rs
@@ -41,7 +41,7 @@ impl ConfigFns for Output {
                 if filepath.exists() {
                     return err!(
                         ConfigErr::InvalidConfig,
-                        &format!(
+                        format!(
                             "Output file '{:?}' already exists, but `overwrite` was not set.",
                             filepath
                         )

--- a/commons/src/config/preamble.rs
+++ b/commons/src/config/preamble.rs
@@ -94,7 +94,7 @@ impl ConfigFns for I18n {
             {
                 return err!(
                     ConfigErr::BadLocaleUsed,
-                    &format!(
+                    format!(
                         "{} locale(s) not supported by default. Only the following locales are allowed: {}.",
                         locales
                             .iter()

--- a/commons/src/config/preamble.rs
+++ b/commons/src/config/preamble.rs
@@ -104,7 +104,7 @@ impl ConfigFns for I18n {
                 .map_err(|_| {
                     pipe!(
                         ConfigErr::InvalidFile,
-                        &format!(
+                        format!(
                             "Failed to read locales file: {}",
                             self.locales_file.as_ref().unwrap().to_string_lossy()
                         )
@@ -138,7 +138,7 @@ impl ConfigFns for I18n {
                 provider.load_buffer(key, req).map_err(|err| {
                     pipe!(
                         ConfigErr::BadLocaleUsed,
-                        &format!(
+                        format!(
                             "Could not find locale '{}' in data file. Cause: {}",
                             locale, err
                         )
@@ -183,7 +183,7 @@ impl I18n {
                     Err(err) => {
                         logid::log!(
                             ConfigErr::InvalidFile,
-                            &format!(
+                            format!(
                                 "Locales file not found: {}. Cause: {}. Using default locales file.",
                                 file_path.to_string_lossy(),
                                 err
@@ -208,7 +208,7 @@ impl I18n {
         let f = File::create(&file_path).map_err(|_| {
             pipe!(
                 ConfigErr::FileCreate,
-                &format!(
+                format!(
                     "Failed to create locales file: {}",
                     file_path.as_ref().to_string_lossy()
                 )
@@ -225,7 +225,7 @@ impl I18n {
         .map_err(|err| {
             pipe!(
                 ConfigErr::LocaleDownload,
-                &format!(
+                format!(
                     "Failed to download locales file: {}. Cause: {}",
                     file_path.as_ref().to_string_lossy(),
                     err,
@@ -281,7 +281,7 @@ impl ConfigFns for Citedata {
             if !file.exists() {
                 return err!(
                     ConfigErr::InvalidFile,
-                    &format!("Citation Style Language file not found: {:?}", file)
+                    format!("Citation Style Language file not found: {:?}", file)
                 );
             }
         }
@@ -290,7 +290,7 @@ impl ConfigFns for Citedata {
             if !reference.exists() {
                 return err!(
                     ConfigErr::InvalidFile,
-                    &format!("Bibliography references file not found: {:?}", reference)
+                    format!("Bibliography references file not found: {:?}", reference)
                 );
             }
         }
@@ -327,7 +327,7 @@ impl ConfigFns for Metadata {
             if !font.exists() {
                 return err!(
                     ConfigErr::InvalidFile,
-                    &format!("Font file not found: {:?}", font)
+                    format!("Font file not found: {:?}", font)
                 );
             }
         }
@@ -363,7 +363,7 @@ impl ConfigFns for HtmlSpecificParameter {
             if !fav.exists() {
                 return err!(
                     ConfigErr::InvalidFile,
-                    &format!("Favicon file not found: {:?}", fav)
+                    format!("Favicon file not found: {:?}", fav)
                 );
             }
         }

--- a/parser/src/security/hashing.rs
+++ b/parser/src/security/hashing.rs
@@ -13,7 +13,7 @@ pub fn get_filehash(file: &Path) -> Result<Vec<u8>, HashingError> {
     let source = fs::read_to_string(file).map_err(|err| {
         pipe!(
             HashingError::FailedReadingFile,
-            &format!("Could not read file: '{:?}'", file),
+            format!("Could not read file: '{:?}'", file),
             add: AddonKind::Info(format!("Cause: {}", err))
         )
     })?;

--- a/render/src/log_id.rs
+++ b/render/src/log_id.rs
@@ -1,4 +1,4 @@
-use logid::{evident::event::intermediary::FinalizedEvent, log_id::LogId, ErrLogId};
+use logid::{evident::event::finalized::FinalizedEvent, log_id::LogId, ErrLogId};
 use thiserror::Error;
 
 #[derive(Debug, Clone, ErrLogId, Error)]


### PR DESCRIPTION
This PR uses the newest logid version to get log filtering.
The filter chosen is `info(infos)`, meaning all log levels of `info` or higher, and `info` addons.

The newest logid version also offers macros to set addons more easily, but existing logs were not changed so far.