### PR TITLE
feat: add rendering for inline math

### DIFF
--- a/inline/src/element/formatting/scoped.rs
+++ b/inline/src/element/formatting/scoped.rs
@@ -11,12 +11,9 @@ macro_rules! scoped_parser {
         pub(crate) fn $fn_name<'slice, 'input>(
             mut parser: InlineParser<'slice, 'input>,
         ) -> (InlineParser<'slice, 'input>, Option<Inline>) {
-            let open_token_opt = parser.iter.peeking_next(|_| true);
-            if open_token_opt.is_none() {
+            let Some(open_token) = parser.iter.peeking_next(|_| true) else {
                 return (parser, None);
-            }
-
-            let open_token = open_token_opt.expect("Checked above to be not None.");
+            };
 
             // No need to check for correct opening format, because parser is only assigned for valid opening tokens.
             if parser.iter.peek_kind().map_or(true, |t| t.is_space()) {
@@ -33,6 +30,7 @@ macro_rules! scoped_parser {
                     !matcher.prev_is_space()
                         && matcher.consumed_matches(&[InlineTokenKind::$kind.into()])
                 })));
+
             scoped_parser.context.flags.allow_implicits = false;
             scoped_parser.context.flags.keep_whitespaces = true;
             scoped_parser.context.flags.logic_only = true;

--- a/inline/src/parser.rs
+++ b/inline/src/parser.rs
@@ -128,8 +128,10 @@ impl<'slice, 'input> InlineParser<'slice, 'input> {
 
             if let Some(parser_fn) = parser_fn_opt {
                 let checkpoint = parser.iter.checkpoint();
+
                 let (updated_parser, inline_opt) = parser_fn(parser);
                 parser = updated_parser;
+
                 match inline_opt {
                     Some(inline) => {
                         inlines.push(inline);

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -20,6 +20,7 @@ unimarkup-inline = { path = "../inline/", version = "0" }
 unimarkup-parser = { path = "../parser/", version = "0" }
 syntect = "5.0"
 spreadsheet-ods = "0.17.0"
+mathemascii = "0.4.0"
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/render/src/html/render.rs
+++ b/render/src/html/render.rs
@@ -6,7 +6,7 @@ use unimarkup_inline::element::{
         Underline, Verbatim,
     },
     textbox::{hyperlink::Hyperlink, TextBox},
-    InlineElement,
+    Inline, InlineElement,
 };
 use unimarkup_parser::elements::indents::{BulletList, BulletListEntry};
 
@@ -294,16 +294,28 @@ impl Renderer<Html> for HtmlRenderer {
     fn render_inline_math(
         &mut self,
         math: &Math,
-        context: &Context,
+        _context: &Context,
     ) -> Result<Html, crate::log_id::RenderError> {
-        // TODO: use proper math rendering once supported
-        let inner = self.render_nested_inline(math.inner(), context)?;
+        // TODO: resolve logic inlines before parsing math.
+        let content_str: String = math
+            .inner()
+            .iter()
+            .filter_map(|i| match i {
+                Inline::Plain(p) => Some(p.content().clone()),
+                _ => None,
+            })
+            .collect();
 
-        Ok(Html::nested(
-            HtmlTag::Span,
-            HtmlAttributes::default(),
-            inner,
-        ))
+        let math = mathemascii::render_mathml(mathemascii::parse(&content_str));
+
+        Ok(Html::with_body(HtmlBody {
+            elements: vec![HtmlElement {
+                tag: HtmlTag::PlainContent,
+                attributes: HtmlAttributes::default(),
+                content: Some(math),
+            }]
+            .into(),
+        }))
     }
 
     fn render_plain(


### PR DESCRIPTION
# Rendering of math

This PR introduces parsing and rendering of Unimarkup math inlines.

## Relevant decisions you made in this PR

An additional dependency [mathemascii](https://github.com/nfejzic/mathemascii) is introduced to parse and render the [AsciiMath](https://asciimath.org) content. 

The parsing is done together with rendering in the `render_inline_math` function. This is sub-optimal, we do not want parsing in rendering implementation. However, we will have to introduce a step (or multiple steps) between parsing and rendering for interpretation of logic, substitution etc. Parsing of math should happen after this resolving step, and before rendering.

## What is now possible? 

You can now use inline math in unimarkup, like this: `$$sum_(i=0)^n i = (n(n+1))/2$$` which renders as <img height="40px" alt="image" src="https://github.com/unimarkup/unimarkup-rs/assets/40841816/4140e0f9-c549-44f0-8a48-444eabed06ec">. 

**NOTE:** I used image embed here, because GitHub's inline math is broken right now: $\sum_{i=0}^{n} i = \frac{n(n+1)}{2}$.

Implementation of block rendering would be fairly easy (check out [formalize](https://github.com/nfejzic/formalize) for example, and [live demo](https://formalize.nfejzic.com)). The only part really missing is the parsing of math blocks. That can be done in a separate PR. 